### PR TITLE
修复 CBB 项目默认构建不通过

### DIFF
--- a/Code/UsingMSBuildCopyOutputFileToFastDebug/Program.cs
+++ b/Code/UsingMSBuildCopyOutputFileToFastDebug/Program.cs
@@ -168,6 +168,7 @@ namespace UsingMSBuildCopyOutputFileToFastDebug
             }
 
             Logger.Warning($"[UsingMSBuildCopyOutputFileToFastDebug] 没有从 MainProjectExecutablePath 和 LaunchSettings 获取到输出的文件夹");
+            return null;
         }
 
         private static IMSBuildLogger Logger { get; } = new MSBuildConsoleLogger();

--- a/Code/UsingMSBuildCopyOutputFileToFastDebug/Program.cs
+++ b/Code/UsingMSBuildCopyOutputFileToFastDebug/Program.cs
@@ -167,12 +167,11 @@ namespace UsingMSBuildCopyOutputFileToFastDebug
                 return new FileInfo(launchMainProjectExecutablePath!);
             }
 
-            throw new ArgumentException($"没有从 MainProjectExecutablePath 和 LaunchSettings 获取到输出的文件夹");
+            Logger.Warning($"[UsingMSBuildCopyOutputFileToFastDebug] 没有从 MainProjectExecutablePath 和 LaunchSettings 获取到输出的文件夹");
         }
 
         private static IMSBuildLogger Logger { get; } = new MSBuildConsoleLogger();
     }
-
 
     [Verb("CopyOutputFile")]
     public class CopyOutputFileOptions


### PR DESCRIPTION
将异常修改为警告即可，因为调试的路径也许是本机的，因此不推送到 Git 仓库，但是依然在仓库安装了此库。拉下来的开发者将构建不通过

例如 IPC 库，加上了 UsingMSBuildCopyOutputFileToFastDebug 工具，但是采用的是配置到开发者自己本机的其他项目进行调试，自然就不会将 LaunchSettings 文件上传上来，于是其他开发者拉下来项目，将会构建不通过，因为没有任何的配置